### PR TITLE
Make header responsive using CSS from Main-Site-Theme

### DIFF
--- a/bar/css/bar.css
+++ b/bar/css/bar.css
@@ -118,3 +118,19 @@
 	width: 974px;
 	margin: 0 auto;
 }
+
+@media (max-width: 979px) {
+	#UCFHBSearch_and_links {
+		display: none;
+	}
+	#UCFHBHeader div.UCFHBWrapper {
+		width: 100%;
+	}
+}
+
+@media (max-width: 767px) {
+	#UCFHBHeader {
+		width: 100%;
+		padding-right: 40px;
+	}
+}

--- a/bar/css/bar.css
+++ b/bar/css/bar.css
@@ -131,6 +131,5 @@
 @media (max-width: 767px) {
 	#UCFHBHeader {
 		width: 100%;
-		padding-right: 40px;
 	}
 }


### PR DESCRIPTION
All of the added CSS was taken from the [Main-Site-Theme](https://github.com/UCF/Main-Site-Theme).  It allows the UCF Header to be used on responsive sites.  One line was removed (margin-left: -20px) as this is unnecessary outside of the Main Site Theme.
