### PR TITLE
Updated bar.css to account for certain default WordPress themes styling

### DIFF
--- a/bar/css/bar.css
+++ b/bar/css/bar.css
@@ -238,6 +238,7 @@
   display: block;
   width: 210px;
   height: 29px;
+  margin-top: 0;
   margin-bottom: 0;
   position: relative;
   text-align: left;
@@ -258,6 +259,7 @@
   height: 23px !important;
   border-radius: 5px 0 0 5px;
   border: solid 1px #fff;
+  box-shadow: none;
   margin: 0;
   padding: 2px 40px 2px 15px;
   position: absolute;


### PR DESCRIPTION
During an initiative to make sure all of our faculty, lab and organization websites use the UCF Header, we've found that certain sites contain default styling that affects the appearance of the ucfhb-search-field and ucfhb-search-form. Specifically for WordPress sites using the popular "Responsive" theme:  https://wordpress.org/themes/responsive/.  
