### PR TITLE
Flexbox support improvements

### DIFF
--- a/bar/css/bar.css
+++ b/bar/css/bar.css
@@ -40,12 +40,18 @@
 
 /* Main wrapper */
 #ucfhb {
+  display: block !important;
   height: 50px;
   width: 100%;
   margin: auto;
   background: #000;
   position: relative;
   z-index: 10000;
+
+  /* Flexbox-specific styles */
+  align-self: flex-start !important;
+  flex: 0 0 auto !important;
+  order: 0 !important;
 }
 
 /* Foundation CSS Framework overrides */


### PR DESCRIPTION
Adds rules to the main header wrapper div to better support sites with global flexbox rules applied (e.g. `body { display: flex; }`).

In particular, this change attempts to fix an issue noted back in November on a site which uses global flexbox rules and height:100% on `html` and `body`; the combination of those rules caused the UCF Header to appear too short when it collapsed below 991px wide, due to flex children being allowed to stretch/shrink vertically.  The main fix to this problem is applying a `flex-grow` value to the header wrapper div, to prevent it from shrinking vertically as the browser size is scaled down.  I've also added some other flex child rules to try to catch as many edge cases as possible.