### PR TITLE
Fixed 1200px breakpoint bar width

### DIFF
--- a/bar/css/1200-breakpoint.css
+++ b/bar/css/1200-breakpoint.css
@@ -3,7 +3,7 @@
  **/
 
  @media (min-width: 1200px) {
-  #ucfhb-inner { width: 1170px; }
+  #ucfhb-inner { width: 1140px; }
   #ucfhb-logo a {
     background-position: 0 -131px;
     width: 322px;


### PR DESCRIPTION
Updated the bar width at the 1200px breakpoint to line up with Bootstrap's -lg breakpoint (with 30px padding width from gutters included).