### PR TITLE
Accessibility updates

### DIFF
--- a/bar/css/bar.css
+++ b/bar/css/bar.css
@@ -258,15 +258,18 @@
   text-align: left;
 }
 #ucfhb-search form label {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  color: #fff; /* Suppresses contrast warnings in WAVE */
   display: block;
+  font-size: 0;
+  line-height: 0 !important;
   position: absolute;
   width: 1px;
   height: 1px;
-  text-indent: -9999px;
-  margin: 0;
+  margin: -1px;
+  overflow: hidden;
   padding: 0;
-  line-height: 0 !important;
-  font-size: 0;
 }
 #ucfhb-search-field {
   width: 148px !important;
@@ -343,12 +346,14 @@
 }
 
 #ucfhb-search-autocomplete-srhelp {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
   display: block;
-  text-indent: -9999px;
   position: absolute;
   width: 1px;
   height: 1px;
-  margin: 0;
+  margin: -1px;
+  overflow: hidden;
   padding: 0;
 }
 

--- a/compiler/assets/university-header-markup.js
+++ b/compiler/assets/university-header-markup.js
@@ -20,13 +20,13 @@
 			'<div id="ucfhb-search">',
 				'<form action="//search.ucf.edu/" data-action-url="//search.ucf.edu#?q=" data-autosearch-url="'+ ucfhbJsonpScript +'" method="get" name="ucfhb-search-form" id="ucfhb-search-form" autocomplete="off">',
 					'<label for="ucfhb-search-field">Search UCF</label>',
-					'<input type="text" name="#q" id="ucfhb-search-field" placeholder="Search UCF" autocomplete="off" autocapitalize="off" aria-autocomplete="list" aria-owns="ucfhb-search-autocomplete" aria-activedescendant="ucfhb-autocomplete-selected" aria-haspopup="true" role="search" />',
+					'<input type="text" name="#q" id="ucfhb-search-field" placeholder="Search UCF" autocomplete="off" autocapitalize="off" aria-autocomplete="list" aria-owns="ucfhb-search-autocomplete" aria-activedescendant="ucfhb-autocomplete-selected" aria-haspopup="true" role="searchbox" />',
 					'<input type="submit" value="Search" id="ucfhb-search-submit" />',
 				'</form>',
 				'<span id="ucfhb-search-autocomplete-srhelp" role="status" aria-live="polite"></span>',
 				'<a id="ucfhb-search-minimal" href="#">Search</a>',
 			'</div>',
 		'</div>',
-		'<ul id="ucfhb-search-autocomplete" tabindex="1" aria-hidden="true" role="listbox"></ul>',
+		'<ul id="ucfhb-search-autocomplete" tabindex="1" aria-hidden="true" aria-label="Search Results" role="listbox"></ul>',
 	'</div>'
 ]

--- a/compiler/assets/university-header-markup.js
+++ b/compiler/assets/university-header-markup.js
@@ -27,6 +27,6 @@
 				'<a id="ucfhb-search-minimal" href="#">Search</a>',
 			'</div>',
 		'</div>',
-		'<ul id="ucfhb-search-autocomplete" tabindex="1" aria-hidden="true" aria-label="Search Results" role="listbox"></ul>',
+		'<ul id="ucfhb-search-autocomplete" aria-hidden="true" role="listbox"></ul>',
 	'</div>'
 ]

--- a/compiler/assets/university-header-markup.js
+++ b/compiler/assets/university-header-markup.js
@@ -20,7 +20,7 @@
 			'<div id="ucfhb-search">',
 				'<form action="//search.ucf.edu/" data-action-url="//search.ucf.edu#?q=" data-autosearch-url="'+ ucfhbJsonpScript +'" method="get" name="ucfhb-search-form" id="ucfhb-search-form" autocomplete="off">',
 					'<label for="ucfhb-search-field">Search UCF</label>',
-					'<input type="text" name="#q" id="ucfhb-search-field" placeholder="Search UCF" autocomplete="off" autocapitalize="off" aria-autocomplete="list" aria-owns="ucfhb-search-autocomplete" aria-activedescendant="ucfhb-autocomplete-selected" aria-haspopup="true" role="searchbox" />',
+					'<input type="text" name="#q" id="ucfhb-search-field" placeholder="Search UCF" autocomplete="off" autocapitalize="off" aria-autocomplete="list" aria-owns="ucfhb-search-autocomplete" aria-haspopup="true" role="searchbox" />',
 					'<input type="submit" value="Search" id="ucfhb-search-submit" />',
 				'</form>',
 				'<span id="ucfhb-search-autocomplete-srhelp" role="status" aria-live="polite"></span>',

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 	<head>
 		<title>UCF University Header</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -79,7 +79,7 @@
 					<div class="alert alert-info">
 						<p>
 							<i class="icon-info-sign"></i> <strong>Note:</strong> These options require that the <code>&lt;script&gt;</code> tag has an ID of <code>ucfhb-script</code>.
-							If your site runs on WordPress, uses <code><a href="http://codex.wordpress.org/Function_Reference/wp_enqueue_script">wp_enqueue_script()</a></code> to enqueue scripts, and requires these overrides, enqueue the University Header script with <code><a href="http://codex.wordpress.org/Function_Reference/wp_enqueue_script">wp_enqueue_script()</a></code> using the parameter(s) above, and add the following snippet to your theme's functions.php file:</p>
+							If your site runs on WordPress, uses <code><a href="http://codex.wordpress.org/Function_Reference/wp_enqueue_script">wp_enqueue_script()</a></code> to enqueue scripts, and requires these overrides, enqueue the University Header script with <code>wp_enqueue_script()</code> using the parameter(s) above, and add the following snippet to your theme's functions.php file:</p>
 							<pre>/**
  * Add ID attribute to registered University Header script.
  **/


### PR DESCRIPTION
Minor accessibility-related updates.  The actual bar's contents should no longer throw any errors, warnings, or low contrast errors when checked against WAVE, and should pass accessibility audits in Chrome developer tools.

I'm adding a separate task to re-add `aria-activedescendant="ucfhb-autocomplete-selected"` to the bar's search field dynamically when the search field is active and search suggestions are present.  I removed it in this set of updates because referencing an ID of an element that isn't _always_ present on the page is technically invalid.

Resolves #6.