### PR TITLE
Force line-height on sprites

### DIFF
--- a/bar/css/bar.css
+++ b/bar/css/bar.css
@@ -16,6 +16,7 @@
 #ucfhb-search-minimal {
   background-image: url('../img/spritesheet-v1.png');
   background-repeat: no-repeat;
+  line-height: 1;
   text-indent: -9999px;
 }
 @media


### PR DESCRIPTION
Ensure line-height modifications on `html`/`body` elements don't bleed into sprites and cause height modifications.